### PR TITLE
Better keyswitch state APIs

### DIFF
--- a/src/kaleidoscope/hardware/ErgoDox.cpp
+++ b/src/kaleidoscope/hardware/ErgoDox.cpp
@@ -225,13 +225,27 @@ void ErgoDox::attachToHost() {
   UDCON &= ~(1 << DETACH);
 }
 
-uint8_t ErgoDox::getKeyswitchStateAtPosition(byte row, byte col) {
-  return bitRead(keyState_[row], col);
+bool ErgoDox::isKeyswitchPressed(byte row, byte col) {
+  return (bitRead(keyState_[row], col) != 0);
 }
 
-uint8_t ErgoDox::getKeyswitchStateAtPosition(uint8_t keyIndex) {
+bool ErgoDox::isKeyswitchPressed(uint8_t keyIndex) {
   keyIndex--;
-  return getKeyswitchStateAtPosition(keyIndex / COLS, keyIndex % COLS);
+  return isKeyswitchPressed(keyIndex / COLS, keyIndex % COLS);
+}
+
+uint8_t ErgoDox::pressedKeyswitchCount() {
+  uint8_t count;
+
+  for (uint8_t r = 0; r < ROWS; r++) {
+    if (!keyState_[r])
+      continue;
+
+    for (uint8_t c = 0; c < COLS; c++) {
+      count += bitRead(keyState_[r], c);
+    }
+  }
+  return count;
 }
 
 }

--- a/src/kaleidoscope/hardware/ErgoDox.h
+++ b/src/kaleidoscope/hardware/ErgoDox.h
@@ -87,17 +87,38 @@ class ErgoDox {
   void unMaskKey(byte row, byte col);
   bool isKeyMasked(byte row, byte col);
 
-  /** Key switch state
+  /** Key switch states
    *
-   * These two methods return the state of the keyswitch at any given position,
-   * regardless of which half they are on. This is a hardware-agnostic access to
-   * the key switch states.
-   *
-   * The first variant requires a row and a column, the second an index, as
-   * returned by `keyIndex`.
+   * These methods offer a way to peek at the key switch states, for those cases
+   * where we need to deal with the state closest to the hardware. Some methods
+   * offer a way to check if a key is pressed, others return the number of
+   * pressed keys.
    */
-  uint8_t getKeyswitchStateAtPosition(byte row, byte col);
-  uint8_t getKeyswitchStateAtPosition(uint8_t keyIndex);
+  /**
+   * Check if a key is pressed at a given position.
+   *
+   * @param row is the row the key is located at in the matrix.
+   * @param col is the column the key is located at in the matrix.
+   *
+   * @returns true if the key is pressed, false otherwise.
+   */
+  bool isKeyswitchPressed(byte row, byte col);
+  /**
+   * Check if a key is pressed at a given position.
+   *
+   * @param keyIndex is the key index, as calculated by `keyIndex`.
+   *
+   * @note Key indexes start at 1, not 0!
+   *
+   * @returns true if the key is pressed, false otherwise.
+   */
+  bool isKeyswitchPressed(uint8_t keyIndex);
+  /**
+   * Check the number of key switches currently pressed.
+   *
+   * @returns the number of keys pressed.
+   */
+  uint8_t pressedKeyswitchCount();
 
   // ErgoDox-specific stuff
   void setStatusLED(uint8_t led, bool state = true);


### PR DESCRIPTION
Instead of `getKeyswitchStateAtPosition`, which is long, unintuitive and feels wrong too, introduce `isKeyswitchPressed`, shorter, better, more reasonable (because it returns a bool - we support only two states anyway!).

Additionally, add `pressedKeyswitchCount()`, which returns the number of key switches pressed.
